### PR TITLE
Fix character limit and add Tailwind config

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -128,7 +128,7 @@ export default function Home() {
   const [showSettingsDialog, setShowSettingsDialog] = useState(false);
   const [showContactDialog, setShowContactDialog] = useState(false);
   const [hasCustomConfig, setHasCustomConfig] = useState(false);
-  const maxChars = parseInt(process.env.NEXT_PUBLIC_MAX_CHARS || "200000");
+  const maxChars = parseInt(process.env.NEXT_PUBLIC_MAX_CHARS || "20000");
 
   useEffect(() => {
     // Update remaining usage count on component mount

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,16 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: ['class'],
+  content: [
+    './app/**/*.{js,jsx}',
+    './components/**/*.{js,jsx}',
+    './lib/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: [
+    require('tailwindcss-animate'),
+    require('tw-animate-css')
+  ]
+};


### PR DESCRIPTION
## Summary
- fix default maxChars value in page.js so frontend matches backend limit
- add missing `tailwind.config.js` for Tailwind CSS builds

## Testing
- `npm run lint` *(fails: `next` not found)*